### PR TITLE
feat: pem download cert check

### DIFF
--- a/checks/aws/aws_kms_keystore_pem/pester.ps1
+++ b/checks/aws/aws_kms_keystore_pem/pester.ps1
@@ -29,7 +29,7 @@ Describe $parentConfiguration.checkDisplayName -ForEach $discovery {
 
         BeforeAll {
             # URL of the .pem file
-            $url = "https://keystore.payments-services.co.uk/cop/payuk.pem" # Hardcoded for now, but need to pass the URL as a variable in the configuration.yaml file
+            $url = $parentConfiguration.certUrl
 
             # Local path to save the downloaded .pem file
             $localFilePath = "/Users/jasondiaz/Downloads/" # Need to create a local directory in the agent and point to it
@@ -49,16 +49,16 @@ Describe $parentConfiguration.checkDisplayName -ForEach $discovery {
 
             # Check if the certificate is valid and whether it is within the last month of validity
             if ($expDate -eq "" -or $expDate -eq $null -or $expDate -eq 0) {
-                throw("ERROR: The certificate has not been found or is invalid. The expiry date value cannot be retrieved.")
+                throw("ERROR: The ${$_.certName} has not been found or is invalid. The expiry date value cannot be retrieved.")
                 $result = 0
             } elseif ($expDate -lt $today) {
-                throw("ERROR: The certificate has expired.")
+                throw("ERROR: The ${$_.certName} has expired.")
                 $result = 0
             } elseif ($expDate -ge $today -and $expDate -le $inAMonth) {
-                throw("WARNING: The certificate needs renewing. $daysLeft days left.")
+                throw("WARNING: The ${$_.certName} needs renewing. $daysLeft days left.")
                 $result = 0
             } else {
-                throw("INFO: The certificate does not need renewing yet. $monthsLeft month(s) still left.")
+                throw("INFO: The ${$_.certName} does not need renewing yet. $monthsLeft month(s) still left.")
                 $result = 1
             }
         }

--- a/checks/aws/aws_kms_keystore_pem/pester.ps1
+++ b/checks/aws/aws_kms_keystore_pem/pester.ps1
@@ -1,0 +1,71 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [hashtable] $parentConfiguration
+)
+
+BeforeDiscovery {
+    # Installing dependencies
+
+    Install-PowerShellModules -moduleNames ("powershell-yaml")
+
+    $configurationFile = $parentConfiguration.configurationFile
+    $stageName = $parentConfiguration.stageName
+    $checkConfiguration = (Get-Content -Path $configurationFile | ConvertFrom-Yaml).($parentConfiguration.checkName)
+
+    # Building the discovery objects
+    $discovery = $checkConfiguration
+    $targets = $discovery.stages | Where-Object { $_.name -eq $stageName } | Select-Object -ExpandProperty targets
+}
+
+# For now, I am checking just one cert, but will have to add a foreach loop to be able to check multiple certs with the same check
+
+Describe $parentConfiguration.checkDisplayName -ForEach $discovery {
+
+    BeforeAll {
+
+    }
+
+    Context "Google cloud composer" -ForEach $targets {
+
+        BeforeAll {
+            # URL of the .pem file
+            $url = "https://keystore.payments-services.co.uk/cop/payuk.pem" # Hardcoded for now, but need to pass the URL as a variable in the configuration.yaml file
+
+            # Local path to save the downloaded .pem file
+            $localFilePath = "/Users/jasondiaz/Downloads/" # Need to create a local directory in the agent and point to it
+
+            # Download the .pem file
+            Invoke-WebRequest -Uri $url -OutFile $localFilePath
+
+            # Load the certificate from the .pem file
+            $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new((Convert-Path "$localFilePath/payuk.pem"))
+
+            # Define dates for check
+            $expDate = $cert.NotAfter
+            $today = Get-Date
+            $inAMonth = (Get-Date).AddMonths(+1)
+            $daysLeft = ($expDate - $today).Days
+            $monthsLeft = [int]($daysLeft/30)
+
+            # Check if the certificate is valid and whether it is within the last month of validity
+            if ($expDate -eq "" -or $expDate -eq $null -or $expDate -eq 0) {
+                throw("ERROR: The certificate has not been found or is invalid. The expiry date value cannot be retrieved.")
+                $result = 0
+            } elseif ($expDate -lt $today) {
+                throw("ERROR: The certificate has expired.")
+                $result = 0
+            } elseif ($expDate -ge $today -and $expDate -le $inAMonth) {
+                throw("WARNING: The certificate needs renewing. $daysLeft days left.")
+                $result = 0
+            } else {
+                throw("INFO: The certificate does not need renewing yet. $monthsLeft month(s) still left.")
+                $result = 1
+            }
+        }
+
+
+        It "Cert is valid for over a month" {
+            $result | Should -Be 1
+        }
+    }
+}


### PR DESCRIPTION
Add new check: aws/aws_kms_keystore_pem

This is required for pay.uk cert expiry maintenance work. Ticket: https://dev.azure.com/PayUK/Pay.UK%20API%20Platform/_boards/board/t/Managed%20Services/Stories?workitem=4368

Looked into how this has been done for other checks and implemented similar changes.