### PR TITLE
add MinSeverity parameter to github cdm check

### DIFF
--- a/checks/github/compliance/example_configuration.yml
+++ b/checks/github/compliance/example_configuration.yml
@@ -6,3 +6,4 @@ github:
   dependabot:
     PRStaleInDays: 10
     PRMaxCount: 3
+    MinSeverity: 'high'

--- a/checks/github/compliance/pester.ps1
+++ b/checks/github/compliance/pester.ps1
@@ -20,10 +20,31 @@ BeforeDiscovery {
     # building the discovery objects
     $repositories = [System.Collections.ArrayList]@()
 
+    # filter open dependabot PRs based on minimum severity
+    $severityRank = @{
+        low = 1
+        moderate = 2
+        high = 3
+        critical = 4
+    }
+
+    $minSeverity = [string]$checkConfiguration.dependabot.MinSeverity
+    if ([string]::IsNullOrWhiteSpace($minSeverity)) {
+        $normalizedMinSeverity = "low"
+    } else {
+        $normalizedMinSeverity = $minSeverity.ToLowerInvariant()
+    }
+
+    if (-not $severityRank.ContainsKey($normalizedMinSeverity)) {
+        throw "Unsupported dependabot.MinSeverity '$minSeverity'. Supported values: low, moderate, high, critical."
+    }
+
+    $minRank = $severityRank[$normalizedMinSeverity]
+
     foreach ($repositoryName in $checkConfiguration.repositories) {
         $dependabotPullRequests = Get-GitHubPullRequest -OwnerName $checkConfiguration.owner -RepositoryName $repositoryName |
-            Where-Object {$_.state -eq 'open' -and $_.user.login -eq 'dependabot[bot]'} |
-                Select-Object -Property title, created_at
+            Where-Object {$_.state -eq 'open' -and $_.user.login -eq 'dependabot[bot]' -and $_.title -match '(low|moderate|high|critical)' -and $severityRank[$Matches[1].ToLowerInvariant()] -ge $minRank} |
+            Select-Object -Property title, created_at
 
         $repositoryObject = [ordered] @{
             repositoryName = $repositoryName


### PR DESCRIPTION
## WHAT
Add MinSeverity parameter to github checks

## WHY
We would like to filter Dependabot PRs by severity (low, moderate, high, critical)

## HOW
Update `pester.ps1` to create a filtered list of PRs by minimum severity before executing checks